### PR TITLE
Add command to extract test results

### DIFF
--- a/config.docif
+++ b/config.docif
@@ -94,7 +94,7 @@ SETUP_SHA_FILES+=("./sandbox/package.xml")
 # COMMAND; SHORT_NAME; DESCRIPTION
 TEST_COMMANDS=()
 TEST_COMMANDS+=( 'catkin_make;compile;A check to see if the code compiles' )
-TEST_COMMANDS+=( 'catkin_make run_tests;tests;A check to see if the tests pass' )
+TEST_COMMANDS+=( 'catkin_make run_tests && catkin_test_results;tests;A check to see if the tests pass' )
 
 # @RECCOMENDED
 # Clean command. Cleans the build files so there is no way the previous build can interfere. Add if you run


### PR DESCRIPTION
catkin_make run_tests always returns as passing (exit code 0), this PR adds the catkin_test_results command to return a failing exit code if the tests fail.
