### PR TITLE
Changes /green_light to /start_detect

### DIFF
--- a/iarrc/launch/circuit.launch
+++ b/iarrc/launch/circuit.launch
@@ -6,7 +6,7 @@
     <include file="$(find iarrc)/launch/stoplight_watcher.launch"/>
     <node name="navigation_controller" pkg="iarrc" type="navigation_controller" output="screen">
         <param name="req_finish_line_crosses" type="int" value="3"/>
-        <param name="startSignal" type="string" value="/green_light"/>
+        <param name="startSignal" type="string" value="/start_detected"/>
     </node>
 </launch>
  

--- a/iarrc/launch/drag.launch
+++ b/iarrc/launch/drag.launch
@@ -6,7 +6,7 @@
     <include file="$(find iarrc)/launch/stoplight_watcher.launch"/>
     <node name="navigation_controller" pkg="iarrc" type="navigation_controller" output="screen">
         <param name="req_finish_line_crosses" type="int" value="1"/>
-        <param name="startSignal" type="string" value="/green_light"/>
+        <param name="startSignal" type="string" value="/start_detected"/>
     </node>
 </launch>
  

--- a/iarrc/launch/stoplight_watcher.launch
+++ b/iarrc/launch/stoplight_watcher.launch
@@ -1,6 +1,6 @@
 <launch>
   <node name="stoplight_watcher" pkg="iarrc" type="stoplight_watcher" output="screen">
-      <param name="stoplight_topic" type="string" value="/green_light" />
+      <param name="stoplight_topic" type="string" value="/start_detected" />
       <param name="img_topic" type="string" value="/camera/image_rect" />
   </node>
 </launch>


### PR DESCRIPTION
If we use /start_detected everywhere, we can easily subscribe to it in an rviz panel for visualization.