### PR TITLE
Add reset signal

### DIFF
--- a/avc/launch/avc.launch
+++ b/avc/launch/avc.launch
@@ -5,5 +5,6 @@
     <node name="navigation_controller" pkg="rr_common" type="navigation_controller" output="screen">
         <param name="req_finish_line_crosses" type="int" value="2"/>
         <param name="startSignal" type="string" value="/start_detected"/>
+        <param name="resetSignal" type="string" value="/reset_detected"/>
     </node>
 </launch>

--- a/iarrc/launch/circuit.launch
+++ b/iarrc/launch/circuit.launch
@@ -7,6 +7,7 @@
     <node name="navigation_controller" pkg="iarrc" type="navigation_controller" output="screen">
         <param name="req_finish_line_crosses" type="int" value="3"/>
         <param name="startSignal" type="string" value="/start_detected"/>
+        <param name="resetSignal" type="string" value="/reset_detected"/>
     </node>
 </launch>
  

--- a/iarrc/launch/drag.launch
+++ b/iarrc/launch/drag.launch
@@ -7,6 +7,7 @@
     <node name="navigation_controller" pkg="iarrc" type="navigation_controller" output="screen">
         <param name="req_finish_line_crosses" type="int" value="1"/>
         <param name="startSignal" type="string" value="/start_detected"/>
+        <param name="resetSignal" type="string" value="/reset_detected"/>
     </node>
 </launch>
  

--- a/iarrc/launch/drag.launch
+++ b/iarrc/launch/drag.launch
@@ -4,7 +4,7 @@
     <include file="$(find iarrc)/launch/ol_reliable.launch"/>
     <include file="$(find iarrc)/launch/race_end_detector.launch"/>
     <include file="$(find iarrc)/launch/stoplight_watcher.launch"/>
-    <node name="navigation_controller" pkg="iarrc" type="navigation_controller" output="screen">
+    <node name="navigation_controller" pkg="rr_common" type="navigation_controller" output="screen">
         <param name="req_finish_line_crosses" type="int" value="1"/>
         <param name="startSignal" type="string" value="/start_detected"/>
         <param name="resetSignal" type="string" value="/reset_detected"/>

--- a/rr_common/src/navigation_controller/navigation_controller.cpp
+++ b/rr_common/src/navigation_controller/navigation_controller.cpp
@@ -1,9 +1,9 @@
 #include <ros/ros.h>
 #include <rr_platform/speed.h>
 #include <rr_platform/steering.h>
+#include <rr_platform/race_reset.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Int8.h>
-#include <std_msgs/Empty.h>
 
 const int WAITING_FOR_START = 0;
 const int RUNNING_PLANNER = 1;
@@ -73,7 +73,7 @@ void finishLineCB(const std_msgs::Int8::ConstPtr &int_msg) {
     finishLineCrosses = int_msg->data;
 }
 
-void resetCB(const std_msgs::Empty &empty_msg) {
+void resetCB(const rr_platform::race_reset &reset_msg) {
     state = WAITING_FOR_START;
     raceStarted = false;
     updateState();

--- a/rr_common/src/navigation_controller/navigation_controller.cpp
+++ b/rr_common/src/navigation_controller/navigation_controller.cpp
@@ -119,6 +119,7 @@ int main(int argc, char** argv) {
         steerMsg.angle = steering;
         steerMsg.header.stamp = ros::Time::now();
         steerPub.publish(steerMsg);
+        ROS_INFO("Current state: %d", state);
 
         rate.sleep();
     }

--- a/rr_common/src/navigation_controller/navigation_controller.cpp
+++ b/rr_common/src/navigation_controller/navigation_controller.cpp
@@ -70,6 +70,11 @@ void finishLineCB(const std_msgs::Int8::ConstPtr &int_msg) {
     finishLineCrosses = int_msg->data;
 }
 
+vold resetCB(const std_msgs::Empty) {
+    state = WAITING_FOR_START;
+    updateState();
+}
+
 int main(int argc, char** argv) {
     ros::init(argc, argv, "navigation_controller");
 
@@ -83,12 +88,14 @@ int main(int argc, char** argv) {
 
     nhp.getParam("req_finish_line_crosses", REQ_FINISH_LINE_CROSSES);
     nhp.getParam("startSignal", startSignal);
+    nhp.getParam("resetSignal", resetSignal);
     ROS_INFO("req finish line crosses = %d", REQ_FINISH_LINE_CROSSES);
 
     auto planSpeedSub = nh.subscribe("plan/speed", 1, planSpeedCB);
     auto planSteerSub = nh.subscribe("plan/steering", 1, planSteerCB);
     auto startLightSub = nh.subscribe(startSignal, 1, startLightCB);
     auto finishLineSub = nh.subscribe("/camera/finish_line_crosses", 1, finishLineCB);
+    auto resetSub = nh.subscribe(resetSignal, 1, resetCB);
 
     speedPub = nh.advertise<rr_platform::speed>("/speed", 1);
     steerPub = nh.advertise<rr_platform::steering>("/steering", 1);

--- a/rr_common/src/navigation_controller/navigation_controller.cpp
+++ b/rr_common/src/navigation_controller/navigation_controller.cpp
@@ -107,7 +107,6 @@ int main(int argc, char** argv) {
     ros::Rate rate(30.0);
     while(ros::ok()) {
         ros::spinOnce();
-        ROS_INFO_STREAM(state);
         updateState();
         //ROS_INFO("Nav Mux = %d, crosses = %d", state, finishLineCrosses);
 

--- a/rr_common/src/navigation_controller/navigation_controller.cpp
+++ b/rr_common/src/navigation_controller/navigation_controller.cpp
@@ -3,12 +3,15 @@
 #include <rr_platform/steering.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Int8.h>
+#include <std_msgs/Empty.h>
 
 const int WAITING_FOR_START = 0;
 const int RUNNING_PLANNER = 1;
 const int FINISHED = 2;
 int REQ_FINISH_LINE_CROSSES;
 std::string startSignal;
+std::string resetSignal;
+
 
 ros::Publisher steerPub;
 ros::Publisher speedPub;
@@ -70,8 +73,9 @@ void finishLineCB(const std_msgs::Int8::ConstPtr &int_msg) {
     finishLineCrosses = int_msg->data;
 }
 
-vold resetCB(const std_msgs::Empty) {
+void resetCB(const std_msgs::Empty &empty_msg) {
     state = WAITING_FOR_START;
+    raceStarted = false;
     updateState();
 }
 
@@ -89,7 +93,7 @@ int main(int argc, char** argv) {
     nhp.getParam("req_finish_line_crosses", REQ_FINISH_LINE_CROSSES);
     nhp.getParam("startSignal", startSignal);
     nhp.getParam("resetSignal", resetSignal);
-    ROS_INFO("req finish line crosses = %d", REQ_FINISH_LINE_CROSSES);
+    ROS_INFO("required finish line crosses = %d", REQ_FINISH_LINE_CROSSES);
 
     auto planSpeedSub = nh.subscribe("plan/speed", 1, planSpeedCB);
     auto planSteerSub = nh.subscribe("plan/steering", 1, planSteerCB);
@@ -103,6 +107,7 @@ int main(int argc, char** argv) {
     ros::Rate rate(30.0);
     while(ros::ok()) {
         ros::spinOnce();
+        ROS_INFO_STREAM(state);
         updateState();
         //ROS_INFO("Nav Mux = %d, crosses = %d", state, finishLineCrosses);
 

--- a/rr_platform/CMakeLists.txt
+++ b/rr_platform/CMakeLists.txt
@@ -34,6 +34,7 @@ add_message_files(
     FILES
     speed.msg
     steering.msg
+    race_reset.msg
     camera_pose.msg
     chassis_state.msg
 )

--- a/rr_platform/launch/logitech_camera.launch
+++ b/rr_platform/launch/logitech_camera.launch
@@ -5,8 +5,8 @@
           args="load libuvc_camera/driver camera_mono_nodelet_manager">
       <param name="vendor" value="0x046d"/>
       <param name="product" value="0x082d"/>
-      <param name="width" value="160"/>
-      <param name="height" value="90"/>
+      <param name="width" value="640"/>
+      <param name="height" value="360"/>
       <param name="video_mode" value="uncompressed"/>
       <param name="frame_rate" value="20"/>
     </node>

--- a/rr_platform/msg/race_reset.msg
+++ b/rr_platform/msg/race_reset.msg
@@ -1,0 +1,1 @@
+# Message for reseting the state in the navigation controller

--- a/rr_rviz_plugins/CMakeLists.txt
+++ b/rr_rviz_plugins/CMakeLists.txt
@@ -31,11 +31,11 @@ include_directories(
 )
 
 set (rviz_plugins_SRCS
-    src/ExamplePanel.cpp
+    src/ResetPanel.cpp
 )
 
 set (rviz_plugins_HDRS
-    include/rr_rviz_plugins/ExamplePanel.h
+    include/rr_rviz_plugins/ResetPanel.h
 )
 
 qt5_wrap_cpp(rviz_plugins_MOCS ${rviz_plugins_HDRS})

--- a/rr_rviz_plugins/CMakeLists.txt
+++ b/rr_rviz_plugins/CMakeLists.txt
@@ -31,10 +31,12 @@ include_directories(
 )
 
 set (rviz_plugins_SRCS
+    src/ExamplePanel.cpp
     src/ResetPanel.cpp
 )
 
 set (rviz_plugins_HDRS
+    include/rr_rviz_plugins/ExamplePanel.h
     include/rr_rviz_plugins/ResetPanel.h
 )
 

--- a/rr_rviz_plugins/include/rr_rviz_plugins/ResetPanel.h
+++ b/rr_rviz_plugins/include/rr_rviz_plugins/ResetPanel.h
@@ -19,7 +19,7 @@ public:
 protected:
     QPushButton *reset_btn;
     ros::NodeHandle nh;
-    ros::Publisher reset_pub = nh.advertise<rr_platform::race_reset>("/reset_detected", 0);
+    ros::Publisher reset_pub;
 
 private slots:
     void resetCallback();

--- a/rr_rviz_plugins/include/rr_rviz_plugins/ResetPanel.h
+++ b/rr_rviz_plugins/include/rr_rviz_plugins/ResetPanel.h
@@ -4,7 +4,7 @@
 #include <ros/ros.h>
 #include <rviz/panel.h>
 #include <QPushButton>
-#include <std_msgs/Empty.h>
+#include <rr_platform/race_reset.h>
 
 /*
  * All of our panels need to be under the rr_rviz_plugins namespace.
@@ -17,9 +17,9 @@ public:
     ResetPanel(QWidget *parent = 0);
 
 protected:
-    ros::NodeHandle nh;
-    ros::Publisher reset_pub = nh.advertise<std_msgs::Empty>("/reset_detected", 0);
     QPushButton *reset_btn;
+    ros::NodeHandle nh;
+    ros::Publisher reset_pub = nh.advertise<rr_platform::race_reset>("/reset_detected", 0);
 
 private slots:
     void resetCallback();

--- a/rr_rviz_plugins/include/rr_rviz_plugins/ResetPanel.h
+++ b/rr_rviz_plugins/include/rr_rviz_plugins/ResetPanel.h
@@ -1,0 +1,30 @@
+#ifndef PROJECT_RESETPANEL_H
+#define PROJECT_RESETPANEL_H
+
+#include <ros/ros.h>
+#include <rviz/panel.h>
+#include <QPushButton>
+#include <std_msgs/Empty.h>
+
+/*
+ * All of our panels need to be under the rr_rviz_plugins namespace.
+ */
+namespace rr_rviz_plugins {
+
+class ResetPanel : public rviz::Panel {
+Q_OBJECT
+public:
+    ResetPanel(QWidget *parent = 0);
+
+protected:
+    ros::NodeHandle nh;
+    ros::Publisher reset_pub = nh.advertise<std_msgs::Empty>("/reset_detected", 0);
+    QPushButton *reset_btn;
+
+private slots:
+    void resetCallback();
+};
+
+}
+
+#endif

--- a/rr_rviz_plugins/plugin_description.xml
+++ b/rr_rviz_plugins/plugin_description.xml
@@ -1,9 +1,9 @@
 <library path="lib/librr_rviz_plugins">
-    <class name="rr_rviz_plugins/ExamplePanel"
-           type="rr_rviz_plugins::ExamplePanel"
+    <class name="rr_rviz_plugins/ResetPanel"
+           type="rr_rviz_plugins::ResetPanel"
            base_class_type="rviz::Panel">
         <description>
-            Example panel for getting started
+            Panel used for reseting the state to race start.
         </description>
     </class>
 </library>

--- a/rr_rviz_plugins/plugin_description.xml
+++ b/rr_rviz_plugins/plugin_description.xml
@@ -1,9 +1,16 @@
 <library path="lib/librr_rviz_plugins">
+    <class name="rr_rviz_plugins/ExamplePanel"
+           type="rr_rviz_plugins::ExamplePanel"
+           base_class_type="rviz::Panel">
+        <description>
+            Example panel for getting started
+        </description>
+    </class>
     <class name="rr_rviz_plugins/ResetPanel"
            type="rr_rviz_plugins::ResetPanel"
            base_class_type="rviz::Panel">
         <description>
-            Panel used for reseting the state to race start.
+            Panel used for reseting the state to race start
         </description>
     </class>
 </library>

--- a/rr_rviz_plugins/src/ResetPanel.cpp
+++ b/rr_rviz_plugins/src/ResetPanel.cpp
@@ -8,6 +8,7 @@ ResetPanel::ResetPanel(QWidget *parent)
   : rviz::Panel(parent) // Base class constructor
 {   
     reset_btn = new QPushButton("Reset!");
+    reset_pub = nh.advertise<rr_platform::race_reset>("/reset_detected", 0);
     connect(reset_btn, SIGNAL (released()), this, SLOT (resetCallback()));
 
     QVBoxLayout *layout = new QVBoxLayout;
@@ -16,8 +17,6 @@ ResetPanel::ResetPanel(QWidget *parent)
 }
 
 void ResetPanel::resetCallback() {
-    ros::NodeHandle nh;
-    ros::Publisher reset_pub = nh.advertise<rr_platform::race_reset>("/reset_detected", 0);
     rr_platform::race_reset reset;
     reset_pub.publish(reset);
 }

--- a/rr_rviz_plugins/src/ResetPanel.cpp
+++ b/rr_rviz_plugins/src/ResetPanel.cpp
@@ -1,0 +1,27 @@
+#include <rr_rviz_plugins/ResetPanel.h>
+#include <QVBoxLayout>
+#include <pluginlib/class_list_macros.h>
+
+namespace rr_rviz_plugins {
+
+ResetPanel::ResetPanel(QWidget *parent)
+  : rviz::Panel(parent) // Base class constructor
+{
+
+    reset_btn = new QPushButton("Reset!");
+    connect(reset_btn, SIGNAL (released()), this, SLOT (resetCallback()));
+
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(reset_btn);
+    setLayout(layout);
+}
+
+void ResetPanel::resetCallback() {
+    std_msgs::Empty reset;
+    //reset_btn->setText("!teseR");
+    reset_pub.publish(reset);
+}
+
+}
+
+PLUGINLIB_EXPORT_CLASS( rr_rviz_plugins::ResetPanel, rviz::Panel)

--- a/rr_rviz_plugins/src/ResetPanel.cpp
+++ b/rr_rviz_plugins/src/ResetPanel.cpp
@@ -18,7 +18,6 @@ ResetPanel::ResetPanel(QWidget *parent)
 
 void ResetPanel::resetCallback() {
     std_msgs::Empty reset;
-    //reset_btn->setText("!teseR");
     reset_pub.publish(reset);
 }
 

--- a/rr_rviz_plugins/src/ResetPanel.cpp
+++ b/rr_rviz_plugins/src/ResetPanel.cpp
@@ -6,8 +6,7 @@ namespace rr_rviz_plugins {
 
 ResetPanel::ResetPanel(QWidget *parent)
   : rviz::Panel(parent) // Base class constructor
-{
-
+{   
     reset_btn = new QPushButton("Reset!");
     connect(reset_btn, SIGNAL (released()), this, SLOT (resetCallback()));
 
@@ -17,7 +16,9 @@ ResetPanel::ResetPanel(QWidget *parent)
 }
 
 void ResetPanel::resetCallback() {
-    std_msgs::Empty reset;
+    ros::NodeHandle nh;
+    ros::Publisher reset_pub = nh.advertise<rr_platform::race_reset>("/reset_detected", 0);
+    rr_platform::race_reset reset;
     reset_pub.publish(reset);
 }
 


### PR DESCRIPTION
The /resetSignal param was added to handle requests to reset the navigation state to WAITING_FOR_START. A button was added as an Rviz panel for this function. #115 #116 