### PR TITLE
Fix for sedani not publishing to chassis_state

### DIFF
--- a/rr_platform/src/sedani_motor_relay_node/sedani_motor_relay_node.cpp
+++ b/rr_platform/src/sedani_motor_relay_node/sedani_motor_relay_node.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
     // Serial port setup
     std::string serial_port_name;
     nhp.param(std::string("serial_port"), serial_port_name, std::string("/dev/ttyACM0"));
-    
+
     SerialPort serial_port;
     if(!serial_port.Open(serial_port_name, 115200)) {
         ROS_FATAL_STREAM("Unable to open serial port: " << serial_port_name);
@@ -101,6 +101,7 @@ int main(int argc, char **argv) {
 
         auto ret = serial_port.ReadLine();
         ROS_INFO_STREAM("motor relay received " << ret);
+        publishData(serial_port.ReadLine());
         rate.sleep();
     }
 


### PR DESCRIPTION
We accidentally removed the ability for the relay node to publish Sedani's data at competition. This adds it back.