### PR TITLE
fixes wrong param in test_scanToPointCloud.test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
       - <<: *install_deps
       - <<: *load_workspace
       - <<: *load_test_cache
-      - run: source /opt/ros/melodic/setup.sh && catkin_make run_tests
+      - run: source /opt/ros/melodic/setup.sh && catkin_make run_tests && catkin_test_results
       - <<: *save_test_cache
 
 workflows:

--- a/rr_platform/test/scanToPointCloud/test_scanToPointCloud.test
+++ b/rr_platform/test/scanToPointCloud/test_scanToPointCloud.test
@@ -1,6 +1,6 @@
 <launch>
     <node pkg="rr_platform" type="scanToPointCloud" name="scanToPointCloud" output="screen" respawn="false">
-    	<param name="min_point_dist" type="double" value="0.0"/>
+    	<param name="min_point_dist" type="double" value="1.0"/>
     </node>
     <test test-name="test_scanToPointCloud" pkg="rr_platform" type="test_scanToPointCloud"/>
 </launch>


### PR DESCRIPTION
This is causing the failed test that CircleCI has been missing for some reason (issue is open for that separate problem)

Edit: also fixes the issue where Circle does not fail on a failed test case. The solution was pretty easy so it's included here. Fixes #210 