### PR TITLE
automates setting gazebo physics settings

### DIFF
--- a/rr_gazebo/scripts/spawn_macaroni_platform.sh
+++ b/rr_gazebo/scripts/spawn_macaroni_platform.sh
@@ -3,3 +3,7 @@
 sleep 3
 
 roslaunch rr_gazebo spawn_macaroni_platform.launch x:=$1 y:=$2 heading:=$3
+
+# set gazebo physics step size so that it uses less CPU resources
+sleep 2
+gz physics --step-size 0.0025 --update-rate 400 --iters 30


### PR DESCRIPTION
Default settings are 1000 updates per second at 1ms per update. Now it runs with significantly less CPU usage and still seems to simulate motion on macaroni_avc.launch equally as well as before