### PR TITLE
fix camera geometry not loading bug

### DIFF
--- a/rr_platform/src/camera/pointcloud_projector.cpp
+++ b/rr_platform/src/camera/pointcloud_projector.cpp
@@ -33,8 +33,7 @@ private:
   void ImageCallback(const sensor_msgs::ImageConstPtr& msg) {
     if (!cam_geom_ready_) {
       NODELET_INFO("Pointcloud projector waiting for camera geometry load");
-      load_info_thread_.join();
-      NODELET_INFO("Camera geometry loaded");
+      return;
     }
 
     const cv::Mat cv_img = cv_bridge::toCvShare(msg, "mono8")->image;


### PR DESCRIPTION
Found what seems to be a bug in the pointcloud camera projector which caused it to hang while waiting for a thread to finish. Found while testing in Gazebo. Perhaps the issue was ros::spinOnce() not working within the other thread? In any case, we can accomplish waiting for that thread by returning from all image callbacks early. (This is what I get for using multiple threads I guess)