### PR TITLE
fixes evgp simulated camera blacklist

### DIFF
--- a/rr_gazebo/launch/evgp_sim.launch
+++ b/rr_gazebo/launch/evgp_sim.launch
@@ -6,7 +6,7 @@
 
     <param name="/use_sim_time" value="true" />
 
-    <rosparam ns="/camera_center/image_color_rect">
+    <rosparam ns="/camera/image_color_rect">
         disable_pub_plugins:
         - "image_transport/compressed"
         - "image_transport/theora"


### PR DESCRIPTION
looks like I changed the camera namespace from /camera_center to /camera at one point and forgot to update the plugin blacklist