### PR TITLE
Fix Laplacian in Simulator

### DIFF
--- a/rr_iarrc/conf/planner_macaroni_sim.yaml
+++ b/rr_iarrc/conf/planner_macaroni_sim.yaml
@@ -3,7 +3,7 @@ collision_hitbox:
   back: 0.1
   side: 0.1
 
-max_speed: 2.0
+max_speed: 1.0
 max_drive_accel: 10
 
 wheel_base: 0.4

--- a/rr_iarrc/launch/perception/laplacian_line_detector_sim.launch
+++ b/rr_iarrc/launch/perception/laplacian_line_detector_sim.launch
@@ -1,5 +1,6 @@
 <launch>
     <node name="laplacian_line_detector" pkg="rr_iarrc" type="laplacian_line_detector" output="screen">
+        <!--Minimum Area to Keep-->
         <param name="min_blob_area" type="int" value="20" />
         <!--Range of the Laplacian Area to Floodfill-->
         <param name="laplacian_threshold_min" type="int" value="-280" />

--- a/rr_iarrc/launch/perception/laplacian_line_detector_sim.launch
+++ b/rr_iarrc/launch/perception/laplacian_line_detector_sim.launch
@@ -1,11 +1,12 @@
 <launch>
     <node name="laplacian_line_detector" pkg="rr_iarrc" type="laplacian_line_detector" output="screen">
-        <!--Minimum Area to Keep-->
-        <param name="perfect_lines_min_cut" type="int" value="10" />
-        <!--Strength of Floodfill-->
-        <param name="Laplacian_threshold" type="int" value="10" />
+        <param name="min_blob_area" type="int" value="20" />
+        <!--Range of the Laplacian Area to Floodfill-->
+        <param name="laplacian_threshold_min" type="int" value="-280" />
+        <param name="laplacian_threshold_max" type="int" value="-5" />
         <!--Strength of Adaptive Thresholding-->
-        <param name="adaptive_mean_threshold" type="int" value="1" />
+        <param name="ignore_adaptive" type="bool" value="False" />
+        <param name="adaptive_mean_threshold" type="int" value="0" />
 
         <!--The larger the height the lower it will be on the screen (Image Height = 1280)-->
         <param name="blockSky_height" type="int" value="550" />


### PR DESCRIPTION
Car in `macaroni_iarrc_circuit` gazebo world with `test_circuit_sim.launch` was overshooting corner because it wasn't properly detecting the lines. Just lowered the Laplacian threshold. Not sure why it suddenly broke. 