### PR TITLE
Add required=true tag to image_transform node in image_to_pcl.launch

### DIFF
--- a/rr_iarrc/launch/perception/image_to_pcl.launch
+++ b/rr_iarrc/launch/perception/image_to_pcl.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node pkg="rr_platform" type="image_transform" name="image_transform" output="screen">
+    <node pkg="rr_platform" type="image_transform" name="image_transform" output="screen" required="true">
         <param name="transform_topics" value="/camera_center/image_color_rect/lines/detection_img"/>
         <param name="camera_info_topic" value="/camera_center/camera_info"/>
         <param name="camera_link_name" value="camera_center"/>


### PR DESCRIPTION
Just like what title says. Makes image_transform node in the image_to_pcl.launch file required. Resolves #333 