### PR TITLE
add required=true attribute to hsv_tuner.launch

### DIFF
--- a/rr_iarrc/launch/perception/hsv_tuner.launch
+++ b/rr_iarrc/launch/perception/hsv_tuner.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <launch>
-    <node name="hsv_tuner" pkg="rr_iarrc" type="hsv_tuner" output="screen">
+    <node name="hsv_tuner" pkg="rr_iarrc" type="hsv_tuner" required="true" output="screen">
         <param name="values_topic" type="string" value= "/hsv_tuned"/>
     	<param name="load_file" type="string" value= "$(find rr_iarrc)/saved_hsv/example.txt"/>
     </node>


### PR DESCRIPTION
Address issue #332 by adding `required="true"` attribute to the node.