### PR TITLE
Added required=true to sign detector node

### DIFF
--- a/rr_iarrc/launch/perception/sign_detector.launch
+++ b/rr_iarrc/launch/perception/sign_detector.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node name="sign_detector" pkg="rr_iarrc" type="sign_detector" output="screen">
+    <node name="sign_detector" pkg="rr_iarrc" type="sign_detector" output="screen" required="true">
         <!-- Sign Detector Params -->
         <param name="front_image_subscription" type="string" value="/camera_center/image_color_rect"/>
 


### PR DESCRIPTION
Added "required=true" to the sign detector node in sign_detector.launch. Resolves #335 