### PR TITLE
Feat/352-sign-detection

### DIFF
--- a/rr_iarrc/launch/perception/sign_detector.launch
+++ b/rr_iarrc/launch/perception/sign_detector.launch
@@ -2,34 +2,20 @@
     <node name="sign_detector" pkg="rr_iarrc" type="sign_detector" output="screen">
         <!-- Sign Detector Params -->
         <param name="front_image_subscription" type="string" value="/camera_center/image_color_rect"/>
+        <param name="sign_string_publisher" type="string" value="/turn_detected"/>
 
         <!--Crop Area for detecting signs (-1 keeps whole screen)-->
-        <param name="roi_x" type="int" value="500" />
-        <param name="roi_y" type="int" value="100" />
-        <param name="roi_width" type="int" value="780" />
-        <param name="roi_height" type="int" value="550" />
+        <param name="roi_x" type="int" value="600" />
+        <param name="roi_y" type="int" value="300" />
+        <param name="roi_width" type="int" value="680" />
+        <param name="roi_height" type="int" value="350" />
 
         <param name="sign_file_package_name" type="string" value="rr_iarrc"/>
         <param name="sign_file_path_from_package" type="string" value="/src/sign_detector/sign_forward.jpg"/>
 
-        <param name="canny_threshold_low" type="double" value="160" /> <!-- 100, 170 -->
-        <param name="canny_threshold_high" type="double" value="200" /> <!-- usually about 2-3 times the low threshold -->
-        <param name="minimum_contour_area" type="double" value="300" />
-        <param name="maxmimum_contour_area" type="double" value="15000" />
-        <param name="straight_match_similarity_threshold" type="double" value="0.4" />
-        <param name="turn_match_similarity_threshold" type="double" value="0.69" />
-        <param name="required_match_count" type="int" value="3" />
-
-        <!-- Stop Bar Detector Params -->
-        <param name="overhead_image_subscription" type="string" value="/camera_center/lines/detection_img_transformed" />
-        <param name="stopBarGoalAngle" type="double" value="0.0" /> <!-- angle in degrees -->
-        <param name="stopBarGoalAngleRange" type="double" value="25.0" /> <!-- we can come at the line from many angles! -->
-        <param name="stopBarTriggerDistance" type="double" value="1.6" /> <!-- distance in meters -->
-        <param name="stopBarTriggerDistanceRight" type="double" value="2.0" /> <!-- distance in meters -->
-        <param name="pixels_per_meter" type="int" value="50" />
-        <param name="houghThreshold" type="int" value="65" /> <!-- see opencv HoughLinesP for more info -->
-        <param name="houghMinLineLength" type="double" value="50" />
-        <param name="houghMaxLineGap" type="double" value="10" />
+        <param name="canny_threshold_low" type="double" value="250" /> <!-- 100, 170 -->
+        <param name="canny_threshold_high" type="double" value="350" /> <!-- usually about 2-3 times the low threshold -->
+        <param name="template_threshold_min" type="double" value="0" />
 
     </node>
 </launch>

--- a/rr_iarrc/launch/perception/sign_detector.launch
+++ b/rr_iarrc/launch/perception/sign_detector.launch
@@ -13,9 +13,10 @@
         <param name="sign_file_package_name" type="string" value="rr_iarrc"/>
         <param name="sign_file_path_from_package" type="string" value="/src/sign_detector/sign_forward.jpg"/>
 
-        <param name="canny_threshold_low" type="double" value="250" /> <!-- 100, 170 -->
-        <param name="canny_threshold_high" type="double" value="350" /> <!-- usually about 2-3 times the low threshold -->
-        <param name="template_threshold_min" type="double" value="0" />
+        <param name="template_confidence_threshold" type="double" value="0.8" />
+        <param name="scalars_start" type="double" value="0.6" />
+        <param name="scalars_end" type="double" value="1.2" />
+        <param name="scalars_num" type="int" value="4" />
 
     </node>
 </launch>

--- a/rr_iarrc/launch/perception/sign_detector.launch
+++ b/rr_iarrc/launch/perception/sign_detector.launch
@@ -14,9 +14,9 @@
         <param name="sign_file_path_from_package" type="string" value="/src/sign_detector/sign_forward.jpg"/>
 
         <param name="template_confidence_threshold" type="double" value="0.8" />
-        <param name="scalars_start" type="double" value="0.6" />
+        <param name="scalars_start" type="double" value="0.3" />
         <param name="scalars_end" type="double" value="1.2" />
-        <param name="scalars_num" type="int" value="4" />
+        <param name="scalars_num" type="int" value="5" />
 
     </node>
 </launch>

--- a/rr_iarrc/src/sign_detector/sign_detector.cpp
+++ b/rr_iarrc/src/sign_detector/sign_detector.cpp
@@ -24,7 +24,7 @@ double scalars_start, scalars_end;
 int scalars_num;
 double template_threshold;
 
-// Credits: https://www.pyimagesearch.com/2015/01/26/multi-scale-template-matching-using-python-opencv/, Daniel Martin
+// Credits: https://www.pyimagesearch.com/2015/01/26/multi-scale-template-matching-using-python-opencv/ and Daniel Martin
 std::tuple<double, cv::Point, int> template_match(const std::vector<cv::Mat> &resized_images, const cv::Mat &template_image) {
     std::tuple<double, cv::Point, int> found = std::make_tuple(-1, cv::Point(-1, -1), -1);
     for(int i = 0; i < resized_images.size(); i++) {
@@ -156,10 +156,10 @@ int main(int argc, char** argv) {
     nhp.param("roi_width", roi_width, -1);  //-1 will default to the whole image
     nhp.param("roi_height", roi_height, -1);
 
-    nhp.param("template_confidence_threshold", template_threshold, 0.5);
-    nhp.param("scalars_start", scalars_start, 0.6);
+    nhp.param("template_confidence_threshold", template_threshold, 0.8);
+    nhp.param("scalars_start", scalars_start, 0.3);
     nhp.param("scalars_end", scalars_end, 1.2);
-    nhp.param("scalars_num", scalars_num, 4);
+    nhp.param("scalars_num", scalars_num, 5);
 
     load_templates(sign_file_package_name, sign_file_path_from_package);
 

--- a/rr_iarrc/src/sign_detector/sign_detector.cpp
+++ b/rr_iarrc/src/sign_detector/sign_detector.cpp
@@ -25,8 +25,8 @@ double scalars_start, scalars_end;
 int scalars_num;
 double template_threshold;
 
-// Credits: https://www.pyimagesearch.com/2015/01/26/multi-scale-template-matching-using-python-opencv/ and
-// Daniel Martin
+// Credits: https://www.pyimagesearch.com/2015/01/26/multi-scale-template-matching-using-python-opencv/
+// and Daniel Martin
 std::tuple<double, cv::Point, int> template_match(const std::vector<cv::Mat> &resized_images,
                                                   const cv::Mat &template_image) {
     std::tuple<double, cv::Point, int> found = std::make_tuple(-1, cv::Point(-1, -1), -1);

--- a/rr_iarrc/src/sign_detector/sign_detector.cpp
+++ b/rr_iarrc/src/sign_detector/sign_detector.cpp
@@ -2,22 +2,20 @@
 #include <ros/package.h>
 #include <ros/publisher.h>
 #include <ros/ros.h>
-#include <rr_msgs/urc_sign.h>
+#include <std_msgs/String.h>
 #include <sensor_msgs/Image.h>
-#include <stdlib.h>
+#include <cstdlib>
+#include <thread>
 
-#include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/opencv.hpp>
 
 cv_bridge::CvImagePtr cv_ptr;
-cv_bridge::CvImagePtr cv_ptrLine;
 ros::Publisher pub;
-ros::Publisher pubLine;
 ros::Publisher pubMove;
 
-rr_msgs::urc_sign moveMsg;
+std_msgs::String moveMsg;
 
 int roi_x;
 int roi_y;
@@ -27,48 +25,39 @@ int roi_height;
 cv::Mat sign_forward;
 cv::Mat sign_left;
 cv::Mat sign_right;
-
-std::vector<cv::Point> template_contour_upright;
-double minContourArea;
-double maxContourArea;
-double straightMatchSimilarityThreshold;
-double turnMatchSimilarityThreshold;
+cv::Mat resized;
+cv::Mat edges;
+cv::Mat result;
 
 double cannyThresholdLow;
 double cannyThresholdHigh;
 
-double stopBarGoalAngle;
-double stopBarGoalAngleRange;
-double stopBarTriggerDistance;
-double stopBarTriggerDistanceRight;
-int houghThreshold;
-double houghMinLineLength;
-double houghMaxLineGap;
-int pixels_per_meter;
+double minVal, curValF, curValR, curValL;
+cv::Point minPos, curPosF, curPosR, curPosL;
+
+double templateThresholdMin;
 
 const std::string RIGHT("right");
 const std::string LEFT("left");
 const std::string STRAIGHT("straight");
 const std::string NONE("none");
 
-struct ArrowSign {
+struct estimate {
     std::string direction;
-    int area;
-    int count;
+    double maxVal;
+    double maxR;
+    cv::Point maxPos;
 };
 
-std::vector<ArrowSign> arrowTrackList{ { RIGHT, 0, 0 }, { LEFT, 0, 0 }, { STRAIGHT, 0, 0 } };
-ArrowSign bestMove = { NONE, 0, 0 };
-int signTriggerCount;
+std::map<std::string, int> arrowCount = { {RIGHT, 0}, {LEFT, 0}, {STRAIGHT, 0}};
+
+std::vector<double> scales{1.6, 1.4, 1.2, 1};
 
 /*
- * This sign dectector uses contours to classified shapes
- * as arrows and determine the direction.
- *
- * A sign must be seen multiple frames IN A ROW to count
+ * This sign detector uses multi-scale template matching
+ * to find arrows
  */
 void sign_callback(const sensor_msgs::ImageConstPtr& msg) {
-    ros::Time start = ros::Time::now();
     cv_ptr = cv_bridge::toCvCopy(msg, "bgr8");
     cv::Mat frame = cv_ptr->image;
 
@@ -77,251 +66,83 @@ void sign_callback(const sensor_msgs::ImageConstPtr& msg) {
         crop = frame;
     } else {
         cv::Rect roi(roi_x, roi_y, roi_width, roi_height);
-        crop = frame(roi);  //@Note: crop is just a reference to that roi of the
-                            // frame, not a copy
+        crop = frame(roi).clone();
     }
 
-    // cv::GaussianBlur(crop, crop, cv::Size(5,5), 0, 0, cv::BORDER_DEFAULT);
-    // //may or may not help Canny
+    cv::cvtColor(crop, crop, CV_BGR2GRAY);
 
-    // Color -> binary; Edge detection
-    cv::Mat edges;
-    cv::Canny(crop, edges, cannyThresholdLow, cannyThresholdHigh);
+    estimate curBest = {NONE, 0, 0, cv::Point()};
 
-    cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
-    cv::morphologyEx(edges, edges, cv::MORPH_CLOSE,
-                     kernel);  // connect possible broken lines
+    // ROS_INFO_STREAM(std:: endl << "New frame");
 
-    // Find arrow-like shapes with Contours
-    std::vector<std::vector<cv::Point>> contours;
-    std::vector<cv::Vec4i> hierarchy;
-    cv::findContours(edges, contours, hierarchy, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+    for (double scale: scales) {
+        cv::resize(crop, resized, cv::Size(crop.cols * scale, crop.rows * scale));
+        double r = 1 / scale;
 
-    cv::drawContours(crop, contours, -1, cv::Scalar(0, 255, 0), 2);  // debug
-
-    std::vector<ArrowSign> foundArrowsList;
-    for (size_t i = 0; i < contours.size(); i++) {
-        std::vector<cv::Point> c = contours[i];  // current contour reference
-        double perimeter = cv::arcLength(c, true);
-        double epsilon = 0.04 * perimeter;
-        std::vector<cv::Point> approxC;
-        cv::approxPolyDP(c, approxC, epsilon, true);
-        //@note: if need be, you can allow size range 6-9 because it is possible one
-        // edge looks like 2 depending on epsilon
-        double contourArea = cv::contourArea(approxC);
-        if (approxC.size() == 7 && contourArea >= minContourArea && contourArea <= maxContourArea) {
-            // check the ratio is arrow-like
-            cv::Rect rect = cv::boundingRect(c);
-            double ratioMin = 1.2;  // 1.5; //ratio of width to height or vice versa
-            double ratioMax = 2.5;  // 2.2; //expanded from real to allow us to view it off angle
-            if ((rect.width * ratioMin <= rect.height && rect.width * ratioMax >= rect.height) ||
-                (rect.height * ratioMin <= rect.width && rect.height * ratioMax >= rect.width)) {
-                cv::rectangle(crop, rect, cv::Scalar(0, 255, 255), 3);  // debug
-
-                if (rect.width > rect.height) {
-                    // Sideways
-                    double matchSimilarity = cv::matchShapes(c, template_contour_upright, CV_CONTOURS_MATCH_I1,
-                                                             0);  //#TODO: change to sideways contours
-                    cv::putText(crop, std::to_string(matchSimilarity), cv::Point(rect.x, rect.y + 25),
-                                cv::FONT_HERSHEY_PLAIN, 2, cv::Scalar(255, 0, 0), 2);
-
-                    if (matchSimilarity <= turnMatchSimilarityThreshold) {
-                        // find top point of the arrow and test its x location
-                        auto extremeY = std::minmax_element(
-                              c.begin(), c.end(), [](cv::Point const& a, cv::Point const& b) { return a.y < b.y; });
-                        if (extremeY.first->x < rect.x + rect.width / 2) {  // topmost point is far left
-                            // left pointing arrow!
-                            cv::putText(crop, LEFT, rect.tl(), cv::FONT_HERSHEY_PLAIN, 2, cv::Scalar(0, 0, 255), 2);
-                            ArrowSign move = { LEFT, rect.area(), 0 };
-                            foundArrowsList.push_back(move);
-                        } else {
-                            // right pointing arrow!
-                            cv::putText(crop, RIGHT, rect.tl(), cv::FONT_HERSHEY_PLAIN, 2, cv::Scalar(0, 0, 255), 2);
-                            ArrowSign move = { RIGHT, rect.area(), 0 };
-                            foundArrowsList.push_back(move);
-                        }
-                    }
-                } else {
-                    // Straight
-                    double matchSimilarity =
-                          cv::matchShapes(approxC, template_contour_upright, CV_CONTOURS_MATCH_I1, 0.0);
-
-                    cv::putText(crop, std::to_string(matchSimilarity), cv::Point(rect.x, rect.y + 50),
-                                cv::FONT_HERSHEY_PLAIN, 2, cv::Scalar(255, 0, 0), 2);
-
-                    if (matchSimilarity <= straightMatchSimilarityThreshold) {
-                        cv::putText(crop, STRAIGHT, rect.tl(), cv::FONT_HERSHEY_PLAIN, 2, cv::Scalar(0, 0, 255), 2);
-                        ArrowSign move = { STRAIGHT, rect.area(), 0 };
-                        foundArrowsList.push_back(move);
-                    }
-                }
-            }
+        if (resized.rows < sign_forward.rows || resized.cols < sign_forward.cols) {
+            break;
         }
+
+        cv::Canny(resized, edges, cannyThresholdLow, cannyThresholdHigh);
+
+        auto f1 = []() {
+            cv::matchTemplate(edges, sign_left, result, CV_TM_CCOEFF_NORMED);
+            cv::minMaxLoc(result, &minVal, &curValL, &minPos, &curPosL);
+        };
+
+        auto f2 = []() {
+            cv::matchTemplate(edges, sign_right, result, CV_TM_CCOEFF_NORMED);
+            cv::minMaxLoc(result, &minVal, &curValR, &minPos, &curPosR);
+        };
+
+        auto f3 = []() {
+            cv::matchTemplate(edges, sign_forward, result, CV_TM_CCOEFF_NORMED);
+            cv::minMaxLoc(result, &minVal, &curValF, &minPos, &curPosF);
+        };
+
+        std::thread th1(f1);
+        std::thread th2(f2);
+        std::thread th3(f3);
+
+        th1.join();
+        th2.join();
+        th3.join();
+
+        if (curValL > curValF && curValL > curValR && curValL > curBest.maxVal && curValL > templateThresholdMin) {
+            curBest.direction = LEFT;
+            curBest.maxVal = curValL;
+            curBest.maxPos = curPosL;
+            curBest.maxR = r;
+        } else if (curValR > curValF && curValR > curValL && curValR > curBest.maxVal && curValR > templateThresholdMin) {
+            curBest.direction = RIGHT;
+            curBest.maxVal = curValR;
+            curBest.maxPos = curPosR;
+            curBest.maxR = r;
+        } else if (curValF > curValL && curValF > curValR && curValF > curBest.maxVal && curValF > templateThresholdMin) {
+            curBest.direction = STRAIGHT;
+            curBest.maxVal = curValF;
+            curBest.maxPos = curPosF;
+            curBest.maxR = r;
+        }
+
+        //ROS_INFO_STREAM(resized.cols << " " << resized.rows << " " << sign_forward.cols << " " << sign_forward.rows);
     }
 
-    // consistency checks
-    for (int i = 0; i < arrowTrackList.size(); i++) {
-        bool wasSeen = false;
-        for (int j = 0; j < foundArrowsList.size(); j++) {
-            ArrowSign currArrow = foundArrowsList[j];
-            if (arrowTrackList[i].direction == currArrow.direction) {
-                wasSeen = true;
-                arrowTrackList[i].count += 1;
-                if (arrowTrackList[i].area > currArrow.area) {  // update rect size
-                    arrowTrackList[i].area = currArrow.area;
-                }
-                int areaTolerance = 150;
-                if (arrowTrackList[i].count >= signTriggerCount &&
-                    arrowTrackList[i].area + areaTolerance >= bestMove.area) {
-                    bestMove.direction = arrowTrackList[i].direction;
-                    bestMove.area = arrowTrackList[i].area;
-                }
-            }
-        }
-        if (!wasSeen) {
-            arrowTrackList[i].count = 0;
-            arrowTrackList[i].area = 0.0;
-        }
-    }
+    ROS_INFO_STREAM(curBest.direction << " " << curBest.maxVal << " " << 1 / curBest.maxR);
 
-    // Some debug images for us
-    // show the bestMatchRect
-    cv::putText(frame, bestMove.direction, cv::Point(0, frame.rows - 1), cv::FONT_HERSHEY_PLAIN, 3,
-                cv::Scalar(255, 0, 255), 2);
-
-    // show where we are cropped to
-    cv::rectangle(crop, cv::Point(0, 0), cv::Point(crop.cols - 1, crop.rows - 1), cv::Scalar(255, 0, 255), 2, 8, 0);
+    cv::Point start, end;
+    start.x = std::round(curBest.maxPos.x * curBest.maxR);
+    start.y = std::round(curBest.maxPos.y * curBest.maxR);
+    end.x = std::round((curBest.maxPos.x + sign_left.cols) * curBest.maxR);
+    end.y = std::round((curBest.maxPos.y + sign_left.rows) * curBest.maxR);
+    cv::rectangle(edges, start, end, (0, 0, 255), 2);
 
     if (pub.getNumSubscribers() > 0) {
-        sensor_msgs::Image outmsg;
-        cv_ptr->image = frame;
-        cv_ptr->encoding = "bgr8";
-        cv_ptr->toImageMsg(outmsg);
-        pub.publish(outmsg);
-    }
-}
-
-/*
- * Uses probablistic Hough to find line segments and determine if they are the
- * stop bar An angle close to 0 is horizontal.
- *
- * @param frame The input overhead image to search inside
- * @param output debug image
- * @param stopBarGoalAngle The angle of line relative to horizontal that makes a
- * stop bar
- * @param stopBarGoalAngleRange Allowable error around stopBarGoalAngle
- * @param triggerDistance Distance to the line that we will send out the message
- * to take action
- * @param threshold HoughLinesP threshold that determines # of votes that make a
- * line
- * @param minLineLength HoughLinesP minimum length of a line segment
- * @param maxLineGap HoughLinesP maxmimum distance between points in the same
- * line
- */
-int findStopBarFromHough(cv::Mat& frame, cv::Mat& output, double& stopBarAngle, double stopBarGoalAngle,
-                         double stopBarGoalAngleRange, double triggerDistance, double triggerDistanceRight,
-                         int threshold, double minLineLength, double maxLineGap) {
-    cv::Mat edges;
-    int ddepth = CV_8UC1;
-    cv::Laplacian(frame, edges, ddepth);  // use edge to get better Hough results
-    convertScaleAbs(edges, edges);
-    edges = frame;                                    //#TOOD: probably laplace then dilate.
-    cv::cvtColor(edges, output, cv::COLOR_GRAY2BGR);  // for debugging
-
-    // Standard Hough Line Transform
-    std::vector<cv::Vec4i> lines;  // will hold the results of the detection
-    double rho = 1;                // distance resolution
-    double theta = CV_PI / 180;    // angular resolution (in radians) pi/180 is one degree res
-
-    cv::HoughLinesP(edges, lines, rho, theta, threshold, minLineLength,
-                    maxLineGap);  // Like hough but for line segments
-    for (size_t i = 0; i < lines.size(); i++) {
-        cv::Vec4i l = lines[i];
-        cv::Point p1(l[0], l[1]);
-        cv::Point p2(l[2], l[3]);
-        cv::line(output, p1, p2, cv::Scalar(0, 0, 255), 2, cv::LINE_AA);
-
-        // calc angle and decide if it is a stop bar
-        double dx = p2.x - p1.x;
-        double dy = p2.y - p1.y;
-        double currAngle = atan(std::fabs(dy / dx)) * 180 / CV_PI;  // in degrees
-
-        cv::Point midpoint = (p1 + p2) * 0.5;
-        cv::circle(output, midpoint, 3, cv::Scalar(255, 0, 0), -1);
-        std::stringstream streamAngle;
-        streamAngle << std::fixed << std::setprecision(2) << currAngle;  // show angle with a couple decimals
-        cv::putText(output, streamAngle.str(), midpoint, cv::FONT_HERSHEY_PLAIN, 1, cv::Scalar(0, 255, 0), 1);
-
-        if (fabs(stopBarGoalAngle - currAngle) <= stopBarGoalAngleRange) {  // allows some amount of angle error
-            // get distance to the line
-            float dist = static_cast<float>((edges.rows - midpoint.y)) / pixels_per_meter;
-
-            cv::line(output, midpoint, cv::Point(midpoint.x, edges.rows), cv::Scalar(0, 255, 255), 1, cv::LINE_AA);
-            std::stringstream streamDist;
-            streamDist << std::fixed << std::setprecision(2) << dist;  // show distance with a couple decimals
-            cv::putText(output, streamDist.str(), cv::Point(midpoint.x, edges.rows - dist / 2), cv::FONT_HERSHEY_PLAIN,
-                        1, cv::Scalar(0, 255, 0), 1);
-
-            if (bestMove.direction == RIGHT && dist <= triggerDistanceRight) {
-                stopBarAngle = currAngle;
-                return 2;
-            } else if (dist <= triggerDistance) {
-                stopBarAngle = currAngle;
-                return 1;  // stop bar detected close to us!
-            }
-        }
-    }
-
-    return 0;  // not close enough or no stop bar here
-}
-
-void stopBar_callback(const sensor_msgs::ImageConstPtr& msg) {
-    cv_ptrLine = cv_bridge::toCvCopy(msg, "mono8");
-    cv::Mat frame = cv_ptrLine->image;
-    cv::Mat debug;
-    double stopBarAngle;
-    int stopBarDetected = findStopBarFromHough(frame, debug, stopBarAngle, stopBarGoalAngle, stopBarGoalAngleRange,
-                                               stopBarTriggerDistance, stopBarTriggerDistanceRight, houghThreshold,
-                                               houghMinLineLength, houghMaxLineGap);
-
-    // debugging draw a line where we trigger
-    cv::Point leftTriggerPoint(0, debug.rows - 1 - stopBarTriggerDistance * pixels_per_meter);
-    cv::Point rightTriggerPoint(debug.cols - 1, debug.rows - 1 - stopBarTriggerDistance * pixels_per_meter);
-    cv::line(debug, leftTriggerPoint, rightTriggerPoint, cv::Scalar(0, 255, 0), 1, cv::LINE_AA);
-
-    cv::Point leftTriggerPoint2(0, debug.rows - 1 - stopBarTriggerDistanceRight * pixels_per_meter);
-    cv::Point rightTriggerPoint2(debug.cols - 1, debug.rows - 1 - stopBarTriggerDistanceRight * pixels_per_meter);
-    cv::line(debug, leftTriggerPoint2, rightTriggerPoint2, cv::Scalar(0, 150, 0), 1, cv::LINE_AA);
-
-    if (stopBarDetected == 2 && bestMove.direction != NONE) {
-        // let the world know
-        moveMsg.header.stamp = ros::Time::now();
-        moveMsg.direction = bestMove.direction;
-        moveMsg.angle = stopBarAngle;
-        pubMove.publish(moveMsg);
-
-        // reset things
-        bestMove.direction = NONE;
-        bestMove.area = 0.0;
-    } else if (stopBarDetected == 1 && bestMove.direction != NONE) {
-        // let the world know
-        moveMsg.header.stamp = ros::Time::now();
-        moveMsg.direction = bestMove.direction;
-        moveMsg.angle = stopBarAngle;
-        pubMove.publish(moveMsg);
-
-        // reset things
-        bestMove.direction = NONE;
-        bestMove.area = 0.0;
-    } else {
-    }
-
-    if (pubLine.getNumSubscribers() > 0) {
-        sensor_msgs::Image outmsg;
-        cv_ptrLine->image = debug;
-        cv_ptrLine->encoding = "bgr8";
-        cv_ptrLine->toImageMsg(outmsg);
-        pubLine.publish(outmsg);
+        sensor_msgs::Image out;
+        cv_ptr->image = edges;
+        cv_ptr->encoding = "mono8";
+        cv_ptr->toImageMsg(out);
+        pub.publish(out);
     }
 }
 
@@ -331,19 +152,9 @@ void loadSignImages(std::string packageName, std::string fileName) {
     sign_forward = cv::imread(path + fileName);
     ROS_ERROR_STREAM_COND(sign_forward.empty(), "Arrow sign image not found at " << path + fileName);
 
-    cv::Mat arrowEdges;
     cv::cvtColor(sign_forward, sign_forward, CV_RGB2GRAY);
-    cv::resize(sign_forward, sign_forward,
-               cv::Size(sign_forward.rows / 6,
-                        sign_forward.cols / 6));  // scale image down to make contour similar scale
-    cv::Canny(sign_forward, arrowEdges, 100,
-              100 * 3);  // get the edges as a binary, thresholds don't matter here
-
-    //#TODO: LOAD THE ROTATED CONTOURS?
-    std::vector<std::vector<cv::Point>> cnts;
-    std::vector<cv::Vec4i> h;
-    cv::findContours(arrowEdges, cnts, h, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE, cv::Point(0, 0));
-    template_contour_upright = cnts[0];
+    cv::resize(sign_forward, sign_forward, cv::Size(sign_forward.rows / 30, sign_forward.cols / 30));
+    cv::Canny(sign_forward, sign_forward, 100, 300);  // get the edges as a binary, thresholds don't matter here
 
     cv::Point2f center(sign_forward.rows / 2, sign_forward.cols / 2);
     cv::Mat rotateLeft = cv::getRotationMatrix2D(center, 90, 1);
@@ -356,53 +167,33 @@ int main(int argc, char** argv) {
 
     ros::NodeHandle nh;
     ros::NodeHandle nhp("~");
+
+    std::string sign_pub;
     std::string image_sub;
-    std::string overhead_image_sub;
     std::string sign_file_path_from_package;
     std::string sign_file_package_name;
 
-    // sign detector params
     nhp.param("roi_x", roi_x, 0);
     nhp.param("roi_y", roi_y, 0);
     nhp.param("roi_width", roi_width, -1);  //-1 will default to the whole image
     nhp.param("roi_height", roi_height, -1);
+
     nhp.param("front_image_subscription", image_sub, std::string("/camera/image_color_rect"));
     nhp.param("sign_file_package_name", sign_file_package_name, std::string("rr_iarrc"));
-    nhp.param("sign_file_path_from_package", sign_file_path_from_package,
-              std::string("/src/sign_detector/sign_forward.jpg"));
-    nhp.param("minimum_contour_area", minContourArea, 300.0);
-    nhp.param("maxmimum_contour_area", maxContourArea, 35000.0);
-    nhp.param("required_match_count", signTriggerCount, 1);
+    nhp.param("sign_file_path_from_package", sign_file_path_from_package, std::string("/src/sign_detector/sign_forward.jpg"));
+    nhp.param("sign_string_publisher", sign_pub, std::string("/turn_detected"));
 
-    nhp.param("straight_match_similarity_threshold", straightMatchSimilarityThreshold, 0.3);
-    nhp.param("turn_match_similarity_threshold", turnMatchSimilarityThreshold, 0.3);
     nhp.param("canny_threshold_low", cannyThresholdLow, 100.0);
     nhp.param("canny_threshold_high", cannyThresholdHigh, 100.0 * 3);
-
-    // stop bar detector params
-    nhp.param("overhead_image_subscription", overhead_image_sub, std::string("/lines/detection_img_transformed"));
-    nhp.param("stopBarGoalAngle", stopBarGoalAngle, 0.0);  // angle in degrees
-    nhp.param("stopBarGoalAngleRange", stopBarGoalAngleRange,
-              15.0);  // angle in degrees
-    nhp.param("stopBarTriggerDistance", stopBarTriggerDistance,
-              0.5);  // distance in meters
-    nhp.param("stopBarTriggerDistanceRight", stopBarTriggerDistanceRight,
-              0.5);  // distance in meters
-    nhp.param("pixels_per_meter", pixels_per_meter, 100);
-    nhp.param("houghThreshold", houghThreshold, 50);
-    nhp.param("houghMinLineLength", houghMinLineLength, 0.0);
-    nhp.param("houghMaxLineGap", houghMaxLineGap, 0.0);
+    nhp.param("template_threshold_min", templateThresholdMin, 4.5e+06);
 
     loadSignImages(sign_file_package_name, sign_file_path_from_package);
 
-    pub = nh.advertise<sensor_msgs::Image>("/sign_detector/signs",
-                                           1);  // debug publish of image
-    pubLine = nh.advertise<sensor_msgs::Image>("/sign_detector/stop_bar",
-                                               1);  // debug publish of image
+    pub = nh.advertise<sensor_msgs::Image>("/sign_detector/signs", 1);  // debug publish of image
+
     // publish the turn move for Urban Challenge Controller
-    pubMove = nh.advertise<rr_msgs::urc_sign>("/turn_detected", 1);
+    pubMove = nh.advertise<std_msgs::String>(sign_pub, 1);
     auto img_real = nh.subscribe(image_sub, 1, sign_callback);
-    auto stopBar = nh.subscribe(overhead_image_sub, 1, stopBar_callback);
 
     ros::spin();
     return 0;


### PR DESCRIPTION
Closes #352 
- Implements multi-scale template matching (https://www.pyimagesearch.com/2015/01/26/multi-scale-template-matching-using-python-opencv/) with multi-threading
- The scalar parameters (start, end, count) specify the minimum size, maximum size and total number of resizes
- If confidence is above 0.8, a string: {LEFT, RIGHT, STRAIGHT} is published to /turn_detected

See demo [here](https://drive.google.com/drive/folders/10cVtAFw-v6oFcvd_eBcXOdzNex_1PRGZ?usp=sharing).
