### PR TITLE
Add 3D Lidar Thresholding

### DIFF
--- a/rr_evgp/conf/costmap_2d_basic_mapping.yaml
+++ b/rr_evgp/conf/costmap_2d_basic_mapping.yaml
@@ -22,8 +22,8 @@ costmap:
     track_unknown_space: true
     observation_sources: laserscan
     laserscan:
-      data_type: LaserScan
-      topic: /scan
+      data_type: PointCloud2
+      topic: /lidar_thresholded
       frame_name: lidar
       expected_update_rate: 100
       observation_persistence: 0.0

--- a/rr_evgp/conf/mapping_global.yaml
+++ b/rr_evgp/conf/mapping_global.yaml
@@ -16,8 +16,8 @@ costmap:
         combination_method: 0
         track_unknown_space: true
         laserscan:
-            data_type: LaserScan
-            topic: /scan
+            data_type: PointCloud2
+            topic: /lidar_thresholded
             frame_name: lidar
             expected_update_rate: 15.0
             observation_persistence: 0.0

--- a/rr_evgp/launch/lidar_z_threshold.launch
+++ b/rr_evgp/launch/lidar_z_threshold.launch
@@ -1,0 +1,15 @@
+<launch>
+  <node pkg="nodelet" type="nodelet" name="pcl_manager" args="manager" output="screen"/>
+
+  <!-- Run a passthrough filter to clean NaNs -->
+  <node pkg="nodelet" type="nodelet" name="passthrough" args="load pcl/PassThrough pcl_manager" output="screen">
+    <remap from="~input" to="/velodyne_points"/>
+    <remap from="~output" to="/lidar_thresholded"/>
+    <rosparam>
+      filter_field_name: z
+      filter_limit_min: 0
+      filter_limit_max: 1
+      filter_limit_negative: False
+    </rosparam>
+  </node>
+</launch>

--- a/rr_evgp/launch/lidar_z_threshold.launch
+++ b/rr_evgp/launch/lidar_z_threshold.launch
@@ -8,7 +8,7 @@
     <rosparam>
       filter_field_name: z
       filter_limit_min: 0
-      filter_limit_max: 1
+      filter_limit_max: 0.1
       filter_limit_negative: False
     </rosparam>
   </node>

--- a/rr_evgp/launch/mapping_sim.launch
+++ b/rr_evgp/launch/mapping_sim.launch
@@ -10,6 +10,8 @@
 <!--        <arg name="map_origin_y" value="$(eval -global_map_size/2)"/>-->
 <!--    </include>-->
 
+    <include file="$(dirname)/lidar_z_threshold.launch"/>
+
     <node pkg="costmap_2d" type="costmap_2d_node" name="global_mapper" output="screen">
         <rosparam command="load" file="$(find rr_evgp)/conf/mapping_common.yaml" subst_value="True"/>
         <rosparam command="load" file="$(find rr_evgp)/conf/mapping_global.yaml" subst_value="True"/>


### PR DESCRIPTION
-Implemented pcl_ros passthrough nodelet from http://wiki.ros.org/pcl_ros/Tutorials/PassThrough%20filtering.
-Min and max z values configurable through the nodelet's launch file lidar_z_threshold.launch.
-Included the nodelet's launch file in mapping_sim.launch.

Example thresholding can be found [here](https://drive.google.com/drive/folders/121lKrUXqV3nXREwL5xyrjmqNuPSjxSk_?usp=sharing).

Resolves #357.