### PR TITLE
makes the local map larger

### DIFF
--- a/rr_evgp/conf/mapping_local.yaml
+++ b/rr_evgp/conf/mapping_local.yaml
@@ -4,8 +4,8 @@ costmap:
     always_send_full_costmap: true
 
     rolling_window: true
-    width: 100
-    height: 100
+    width: 350
+    height: 350
 
     plugins:
         - {name: "global", type: "costmap_2d::StaticLayer"}


### PR DESCRIPTION
Makes the local map 3.5 times larger so that it always covers the entire track. This helps prevent the car from trying to drive through a wall. 