### PR TITLE
Update ci/cd info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ This repository is comprised of multiple ROS packages and one sandbox folder for
 
 The following files and folders enable our continuous integration system.
 
-* .circleci
-* Dockerfile
+* .github
 
 ## Installation
 


### PR DESCRIPTION
removed the two bullet points in the readme for .circleci and Dockerfile and added a bullet point for .github