### PR TITLE
Ros2/build 

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,11 +4,10 @@ on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04
+    container:
+      image: osrf/ros:humble-desktop
     steps:
-      - uses: ros-tooling/setup-ros@v0.3
-        with:
-          required-ros-distributions: humble
-      # Pass the file to the action
+      - uses: actions/checkout@v2
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: humble 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: humble 
-          vcs-repo-file-url:  'https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos'
           skip-tests: True
     if: always()
   


### PR DESCRIPTION
So figured out how to not have to build from source and it wasn't too bad. Basically steal a docker container from open robotics the people who made ros. It should work well though people have had complaints about the docker container.